### PR TITLE
freebsd: fix stat call for FreeBSD

### DIFF
--- a/ocamlbuild_goodies/jane_street_ocamlbuild_goodies.ml
+++ b/ocamlbuild_goodies/jane_street_ocamlbuild_goodies.ml
@@ -65,7 +65,7 @@ let track_external_deps = function
 
     let stat, md5sum =
       match run_and_read "uname" |> String.trim with
-      | "Darwin" ->
+      | "Darwin" | "FreeBSD" ->
         (S [A "stat"; A "-f"; A "%d:%i:%m"],
          A "md5")
       | _ ->


### PR DESCRIPTION
The stat that ships with FreeBSD has the same command-line options as OS X.
