### PR TITLE
Fixed stat call for NetBSD

### DIFF
--- a/ocamlbuild_goodies/jane_street_ocamlbuild_goodies.ml
+++ b/ocamlbuild_goodies/jane_street_ocamlbuild_goodies.ml
@@ -65,7 +65,7 @@ let track_external_deps = function
 
     let stat, md5sum =
       match run_and_read "uname" |> String.trim with
-      | "Darwin" | "FreeBSD" ->
+      | "Darwin" | "FreeBSD" | "NetBSD" ->
         (S [A "stat"; A "-f"; A "%d:%i:%m"],
          A "md5")
       | _ ->


### PR DESCRIPTION
NetBSD uses the same stat version as Darwin and FreeBSD; this patch reflects that.
